### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 Where it all begins: [https://github.com/apple/swift](https://github.com/apple/swift).
 
-####LeetCode Solutions in Swift 3.1
+#### LeetCode Solutions in Swift 3.1
 * Designed for your next job interview in Swift.
 * Optimal solutions handpicked from the LeetCode community.
 * Best time/space complexity guaranteed. (Think about **O(1) space** in Binary Tree Inorder Traversal. It's that good.)
@@ -10,9 +10,9 @@ Where it all begins: [https://github.com/apple/swift](https://github.com/apple/s
 
 Please note: Subscript-based O(1) time random access to characters inside a string is not supported by Swift, due to [the way Swift strings are stored](http://oleb.net/blog/2014/07/swift-strings/). Amortized O(1) time random access could be achieved if we manually slice the string and convert it into an array.
 
-#####To run all test cases, launch the project and hit ⌘ + U.
+##### To run all test cases, launch the project and hit ⌘ + U.
 
-#####Requires Xcode 8.3.1 (8E1000a) or later.
+##### Requires Xcode 8.3.1 (8E1000a) or later.
 
 1. [Two Sum](https://oj.leetcode.com/problems/two-sum/) - Medium - [Swift Solution](./Solutions/Solutions/Medium/Medium_001_Two_Sum.swift) - [ObjC Solution](./Solutions/Solutions_ObjC/Medium/ObjC_Medium_001_Two_Sum.m) - [Test Cases](./Solutions/SolutionsTests/Medium/Medium_001_Two_Sum_Test.swift) - t=O(N), s=O(N) - Inspired by [@naveed.zafar](https://leetcode.com/discuss/10947/accepted-c-o-n-solution)
 2. [Add Two Numbers](https://oj.leetcode.com/problems/add-two-numbers/) - Medium - [Swift Solution](./Solutions/Solutions/Medium/Medium_002_Add_Two_Numbers.swift) - [ObjC Solution](./Solutions/Solutions_ObjC/Medium/ObjC_Medium_002_Add_Two_Numbers.m) - [Test Cases](./Solutions/SolutionsTests/Medium/Medium_002_Add_Two_Numbers_Test.swift) - t=O(N), s=O(1) - Inspired by [@potpie](https://leetcode.com/discuss/2308/is-this-algorithm-optimal-or-what)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
